### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cloud Foundry Java Client
 
-[![Maven Central](https://img.shields.io/maven-central/v/io.pivotal/pivotal-cloudfoundry-client/3.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aio.pivotal%20AND%20a%3Apivotal-cloudfoundry-*)
+[![Maven Central](https://img.shields.io/maven-central/v/io.pivotal/pivotal-cloudfoundry-client/3.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3Aio.pivotal%20AND%20a%3Apivotal-cloudfoundry-*)
 
 | Artifact | Javadocs
 | -------- | --------
@@ -50,7 +50,7 @@ Snapshot artifacts can be found in the Spring snapshot repository:
     <repository>
         <id>spring-snapshots</id>
         <name>Spring Snapshots</name>
-        <url>http://repo.spring.io/snapshot</url>
+        <url>https://repo.spring.io/snapshot</url>
         <snapshots>
             <enabled>true</enabled>
         </snapshots>
@@ -74,7 +74,7 @@ Snapshot artifacts can be found in the Spring snapshot repository:
 
 ```groovy
 repositories {
-    maven { url 'http://repo.spring.io/snapshot' }
+    maven { url 'https://repo.spring.io/snapshot' }
     ...
 }
 ```
@@ -179,7 +179,7 @@ This project is released under version 2.0 of the [Apache License][l].
 [d]: https://github.com/cloudfoundry/java-client
 [e]: https://github.com/cloudfoundry/java-client/issues
 [g]: https://gradle.org
-[h]: http://projectreactor.io/io/docs/api/reactor/io/netty/http/HttpClient.html
+[h]: https://projectreactor.io/io/docs/api/reactor/io/netty/http/HttpClient.html
 [i]: https://github.com/pivotal-cf/pcfdev
 [l]: https://www.apache.org/licenses/LICENSE-2.0
 [m]: https://maven.apache.org

--- a/pivotal-cloudfoundry-client/src/main/java/io/pivotal/scheduler/v1/calls/Calls.java
+++ b/pivotal-cloudfoundry-client/src/main/java/io/pivotal/scheduler/v1/calls/Calls.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Calls {
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#create-call">Create Call</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#create-call">Create Call</a> request
      *
      * @param request the Create Call request
      * @return the response to the Create Call request
@@ -32,7 +32,7 @@ public interface Calls {
     Mono<CreateCallResponse> create(CreateCallRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#delete-a-call">Delete a Call</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#delete-a-call">Delete a Call</a> request
      *
      * @param request the Delete a Call request
      * @return the response to the Delete a Call request
@@ -40,7 +40,7 @@ public interface Calls {
     Mono<Void> delete(DeleteCallRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#deletes-the-given-schedule-for-the-given-job">Delete a Call Schedule</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#deletes-the-given-schedule-for-the-given-job">Delete a Call Schedule</a> request
      *
      * @param request the Delete a Call Schedule request
      * @return the response to the Delete a Call Schedule request
@@ -48,7 +48,7 @@ public interface Calls {
     Mono<Void> deleteSchedule(DeleteCallScheduleRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#execute-a-call-as-soon-as-possible">Execute a Call</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#execute-a-call-as-soon-as-possible">Execute a Call</a> request
      *
      * @param request the Execute a Call request
      * @return the response to the Execute a Call request
@@ -56,7 +56,7 @@ public interface Calls {
     Mono<ExecuteCallResponse> execute(ExecuteCallRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#get-a-call">Get a Call</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#get-a-call">Get a Call</a> request
      *
      * @param request the Get a Call request
      * @return the response to the Get a Call request
@@ -64,7 +64,7 @@ public interface Calls {
     Mono<GetCallResponse> get(GetCallRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#get-all-calls-within-space">List Calls</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#get-all-calls-within-space">List Calls</a> request
      *
      * @param request the List Calls request
      * @return the response to the List Calls request
@@ -72,7 +72,7 @@ public interface Calls {
     Mono<ListCallsResponse> list(ListCallsRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-execution-histories-for-a-call">List Call Histories</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-execution-histories-for-a-call">List Call Histories</a> request
      *
      * @param request the List Call Histories request
      * @return the response to the List Call Histories request
@@ -80,7 +80,7 @@ public interface Calls {
     Mono<ListCallHistoriesResponse> listHistories(ListCallHistoriesRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-execution-histories-for-a-call-and-schedule">List Call Schedule Histories</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-execution-histories-for-a-call-and-schedule">List Call Schedule Histories</a> request
      *
      * @param request the List Call Schedule Histories request
      * @return the response to the List Call Schedule Histories request
@@ -88,7 +88,7 @@ public interface Calls {
     Mono<ListCallScheduleHistoriesResponse> listScheduleHistories(ListCallScheduleHistoriesRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-execution-histories-for-a-call">List Call Schedules</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-execution-histories-for-a-call">List Call Schedules</a> request
      *
      * @param request the List Call Schedules request
      * @return the response to the List Call Schedules request
@@ -96,7 +96,7 @@ public interface Calls {
     Mono<ListCallSchedulesResponse> listSchedules(ListCallSchedulesRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#schedules-a-call-to-run-later">Schedule a Call</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#schedules-a-call-to-run-later">Schedule a Call</a> request
      *
      * @param request the Schedule a Call request
      * @return the response to the Schedule a Call request

--- a/pivotal-cloudfoundry-client/src/main/java/io/pivotal/scheduler/v1/jobs/Jobs.java
+++ b/pivotal-cloudfoundry-client/src/main/java/io/pivotal/scheduler/v1/jobs/Jobs.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Mono;
 public interface Jobs {
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#create-job">Create Job</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#create-job">Create Job</a> request
      *
      * @param request the Create Job request
      * @return the response to the Create Job request
@@ -32,7 +32,7 @@ public interface Jobs {
     Mono<CreateJobResponse> create(CreateJobRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#delete-a-job">Delete a Job</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#delete-a-job">Delete a Job</a> request
      *
      * @param request the Delete a Job request
      * @return the response to the Delete a Job request
@@ -40,7 +40,7 @@ public interface Jobs {
     Mono<Void> delete(DeleteJobRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#deletes-the-given-schedule-for-the-given-job_1">Delete a Job Schedule</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#deletes-the-given-schedule-for-the-given-job_1">Delete a Job Schedule</a> request
      *
      * @param request the Delete a Job Schedule request
      * @return the response to the Delete a Job Schedule request
@@ -48,7 +48,7 @@ public interface Jobs {
     Mono<Void> deleteSchedule(DeleteJobScheduleRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#execute-a-job-as-soon-as-possible">Execute a Job as soon as possible</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#execute-a-job-as-soon-as-possible">Execute a Job as soon as possible</a> request
      *
      * @param request the Execute Job request
      * @return the response to the Execute Job request
@@ -56,7 +56,7 @@ public interface Jobs {
     Mono<ExecuteJobResponse> execute(ExecuteJobRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#get-a-job">Get a Job</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#get-a-job">Get a Job</a> request
      *
      * @param request the Get a Job request
      * @return the response to the Get a Job request
@@ -64,7 +64,7 @@ public interface Jobs {
     Mono<GetJobResponse> get(GetJobRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#get-all-jobs-within-space">List Jobs</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#get-all-jobs-within-space">List Jobs</a> request
      *
      * @param request the List Job request
      * @return the response to the List Job request
@@ -72,7 +72,7 @@ public interface Jobs {
     Mono<ListJobsResponse> list(ListJobsRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-execution-histories-for-a-job">List Job Histories</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-execution-histories-for-a-job">List Job Histories</a> request
      *
      * @param request the List Job Histories request
      * @return the response to the List Job Histories request
@@ -80,7 +80,7 @@ public interface Jobs {
     Mono<ListJobHistoriesResponse> listHistories(ListJobHistoriesRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-execution-histories-for-a-job-and-schedule">List all execution histories for a Job and Schedule</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-execution-histories-for-a-job-and-schedule">List all execution histories for a Job and Schedule</a> request
      *
      * @param request the List Job Schedule Histories request
      * @return the response to the List Job Schedule Histories request
@@ -88,7 +88,7 @@ public interface Jobs {
     Mono<ListJobScheduleHistoriesResponse> listScheduleHistories(ListJobScheduleHistoriesRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-schedules-for-a-job">List Job Schedules</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#gets-all-schedules-for-a-job">List Job Schedules</a> request
      *
      * @param request the List Job Schedules request
      * @return the response to the List Job Schedules request
@@ -96,7 +96,7 @@ public interface Jobs {
     Mono<ListJobSchedulesResponse> listSchedules(ListJobSchedulesRequest request);
 
     /**
-     * Makes the <a href="http://docs.pivotal.io/pcf-scheduler/1-1/api/#schedules-a-job-to-run-later">Schedule a Job to run later</a> request
+     * Makes the <a href="https://docs.pivotal.io/pcf-scheduler/1-1/api/#schedules-a-job-to-run-later">Schedule a Job to run later</a> request
      *
      * @param request the Schedule Job request
      * @return the response to the Schedule Job request


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://reactivex.io (200) with 1 occurrences could not be migrated:  
   ([https](https://reactivex.io) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://projectreactor.io/io/docs/api/reactor/io/netty/http/HttpClient.html (301) with 1 occurrences migrated to:  
  https://projectreactor.io/io/docs/api/reactor/io/netty/http/HttpClient.html ([https](https://projectreactor.io/io/docs/api/reactor/io/netty/http/HttpClient.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.pivotal.io/pcf-scheduler/1-1/api/ with 20 occurrences migrated to:  
  https://docs.pivotal.io/pcf-scheduler/1-1/api/ ([https](https://docs.pivotal.io/pcf-scheduler/1-1/api/) result 200).
* [ ] http://search.maven.org/ with 1 occurrences migrated to:  
  https://search.maven.org/ ([https](https://search.maven.org/) result 200).
* [ ] http://repo.spring.io/snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).